### PR TITLE
Remove extraneous forward slash in example output

### DIFF
--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -271,7 +271,7 @@ $ pwd
 {: .language-bash}
 
 ~~~
-//home/username/data-shell/thesis
+/home/username/data-shell/thesis
 ~~~
 {: .output}
 

--- a/_episodes/03-create.md
+++ b/_episodes/03-create.md
@@ -396,7 +396,7 @@ Sure enough,
 `ls` shows us that `thesis` now contains one file called `quotes.txt`:
 
 ~~~
-$ ls thesis
+$ ls
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
One of the outputs from the commands has an extra slash in it.